### PR TITLE
修复veux初始化数据异常bug

### DIFF
--- a/lib/index.vue
+++ b/lib/index.vue
@@ -239,9 +239,8 @@ export default {
     _setContent(value) {
       if (this.isReady) {
         value === this.editor.getContent() || this.editor.setContent(value);
-      } else {
-        this.readyValue = value;
       }
+      this.readyValue = value;
     }
   },
   beforeDestroy() {


### PR DESCRIPTION
vuex中初始化的值为上次neditor的值。
neditor初始化后会先触发watch事件，将新的值写入富文本框，后触发ready事件，而ready事件获取的值为初始化时携带的旧值, 因为watch事件执行时neditor已经ready。